### PR TITLE
Fix a bug caused by multiple CSS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+tmp/

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
     "karma-source-map-support": "^1.2.0",
-    "mkdirp": "^0.5.1",
     "onchange": "^3.3.0",
     "rimraf": "^2.6.1",
+    "shelljs": "^0.8.2",
     "twine-utils": "^1.2.4",
     "uglifyify": "^3.0.4",
     "watchify": "^3.9.0"


### PR DESCRIPTION
Fix a bug caused by having multiple CSS files in the `src/` directory.

`cssnano` does not support globbing (ex. `src/*.css`). The second CSS file is actually being interpreted as an `output` argument causing it to be overwritten, and no output to be written to `stdout`.

To work around this, use a cross-platform version of  `cat` (by way of [ShellJS](https://github.com/shelljs/shelljs)) to concatenate all CSS files and pass _that_ to `cssnano`.

Replace `mkdirp` with ShellJS' built-in `mkdir()` function.