### PR TITLE
remove mandatory checkpoint in start()

### DIFF
--- a/lib/Story.js
+++ b/lib/Story.js
@@ -265,7 +265,6 @@ class Story {
       /* Start the story; mark that we're at a checkpoint. */
 
       this.show(this.startPassage);
-      this.atCheckpoint = true;
     }
   }
 


### PR DESCRIPTION
This is related to issue #198. As I mentioned there, I thought about adding a mandatory checkpoint to the `popstate` event listener. However, it occurred to me that while that may be more beginner friendly, removing the mandatory checkpoint in `start()` would be more versatile. One could easily add a checkpoint to one's starting passage if one wants, but it's more difficult to remove the checkpoint from the starting passage if one wants to do that. Some games don't have a save point until a little bit into the game, so that makes sense to me. Also, it could be useful to have a starting passage that runs some code, then immediately `show()` a second passage, which would be the first passage the user sees, and could include a `checkpoint()` manually.