### PR TITLE
move event trigger sm.checkpoint.added

### DIFF
--- a/lib/Story.js
+++ b/lib/Story.js
@@ -350,6 +350,7 @@ class Story {
             '',
             ''
           );
+          $.event.trigger('sm.checkpoint.added', { name: idOrName });
         } else {
           window.history.replaceState(
             {
@@ -372,8 +373,6 @@ class Story {
 
         $.event.trigger('sm.checkpoint.failed', { error: e });
       }
-
-      $.event.trigger('sm.checkpoint.added', { name: idOrName });
     }
 
     window.passage = passage;

--- a/lib/Story.js
+++ b/lib/Story.js
@@ -350,7 +350,7 @@ class Story {
             '',
             ''
           );
-          $.event.trigger('sm.checkpoint.added', { name: idOrName });
+          $.event.trigger('sm.checkpoint.added', { name: window.passage.name });
         } else {
           window.history.replaceState(
             {


### PR DESCRIPTION
I noticed that the `sm.checkpoint.added` event was triggering every time a passage was shown, and not only when a checkpoint is added. I'm not 100% sure this is unintentional, but I'm guessing from the name of the event that it is.