### PR TITLE
Add support to onclick custom code in links

### DIFF
--- a/src/Markdown.js
+++ b/src/Markdown.js
@@ -1,14 +1,22 @@
 class Markdown {
   static parse (text) {
     const rules = [
+      // [[rename|destination][onclick]]
+      [/\[\[(.*?)\|(.*?)\](?:\[(.*?)\])?\]/g, (m, p1, p2, p3 = "") => `<tw-link role="link" onclick="${p3.replaceAll("s.", "window.story.state.")}" data-passage="${p2}">${p1}</tw-link>`],
       // [[rename|destination]]
-      [/\[\[(.*?)\|(.*?)\]\]/g, '<tw-link role="link" data-passage="$2">$1</tw-link>'],
+      //[/\[\[(.*?)\|(.*?)\]\]/g, '<tw-link role="link" data-passage="$2">$1</tw-link>'],
+      // [[rename->dest][onclick]]
+      [/\[\[(.*?)->(.*?)\](?:\[(.*?)\])?\]/g, (m, p1, p2, p3 = "") => `<tw-link role="link" onclick="${p3.replaceAll("s.", "window.story.state.")}" data-passage="${p2}">${p1}</tw-link>`],
       // [[rename->dest]]
-      [/\[\[(.*?)->(.*?)\]\]/g, '<tw-link role="link" data-passage="$2">$1</tw-link>'],
+      //[/\[\[(.*?)->(.*?)\]\]/g, '<tw-link role="link" data-passage="$2">$1</tw-link>'],
+      // [[dest<-rename][onclick]]
+      [/\[\[(.*?)<-(.*?)\](?:\[(.*?)\])?\]/g, (m, p1, p2, p3 = "") => `<tw-link role="link" onclick="${p3.replaceAll("s.", "window.story.state.")}" data-passage="${p1}">${p2}</tw-link>`],
       // [[dest<-rename]]
-      [/\[\[(.*?)<-(.*?)\]\]/g, '<tw-link role="link" data-passage="$1">$2</tw-link>'],
+      //[/\[\[(.*?)<-(.*?)\]\]/g, '<tw-link role="link" data-passage="$1">$2</tw-link>'],
+      // [[destination][onclick]]
+      [/\[\[(.*?)\](?:\[(.*?)\])?\]/g, (m, p1, p2 = "") => `<tw-link role="link" onclick="${p2.replaceAll("s.", "window.story.state.")}" data-passage="${p1}">${p1}</tw-link>`],
       // [[destination]]
-      [/\[\[(.*?)\]\]/g, '<tw-link role="link" data-passage="$1">$1</tw-link>']
+      //[/\[\[(.*?)\]\]/g, '<tw-link role="link" data-passage="$1">$1</tw-link>']
     ];
 
     rules.forEach(([rule, template]) => {

--- a/test/Markdown.test.js
+++ b/test/Markdown.test.js
@@ -3,19 +3,67 @@ const Markdown = require('../src/Markdown.js');
 describe('Markdown', () => {
   describe('parse()', () => {
     it('Should produce classic link', () => {
-      expect(Markdown.parse('[[dest]]')).toBe('<tw-link role="link" data-passage="dest">dest</tw-link>');
+      expect(Markdown.parse('[[dest]]')).toBe('<tw-link role="link" onclick="" data-passage="dest">dest</tw-link>');
+    });
+
+    it('Should produce classic link with custom onclick', () => {
+      expect(Markdown.parse('[[dest][onclick]]')).toBe('<tw-link role="link" onclick="onclick" data-passage="dest">dest</tw-link>');
+    });
+
+    it('Should produce classic link both simple and with custom onclick', () => {
+      expect(Markdown.parse('... [[dest]] ... [[dest][onclick]]')).toBe('... <tw-link role="link" onclick="" data-passage="dest">dest</tw-link> ... <tw-link role="link" onclick="onclick" data-passage="dest">dest</tw-link>');
+    });
+
+    it('Should produce classic link with custom onclick with state reference', () => {
+      expect(Markdown.parse('[[dest][s.onclick=1]]')).toBe('<tw-link role="link" onclick="window.story.state.onclick=1" data-passage="dest">dest</tw-link>');
     });
 
     it('Should produce bar link', () => {
-      expect(Markdown.parse('[[rename|dest]]')).toBe('<tw-link role="link" data-passage="dest">rename</tw-link>');
+      expect(Markdown.parse('[[rename|dest]]')).toBe('<tw-link role="link" onclick="" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce bar link with custom onclick', () => {
+      expect(Markdown.parse('[[rename|dest][onclick]]')).toBe('<tw-link role="link" onclick="onclick" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce bar link both simple and with custom onclick', () => {
+      expect(Markdown.parse('... [[rename|dest]] ... [[rename|dest][onclick]]')).toBe('... <tw-link role="link" onclick="" data-passage="dest">rename</tw-link> ... <tw-link role="link" onclick="onclick" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce bar link with custom onclick with state reference', () => {
+      expect(Markdown.parse('[[rename|dest][s.onclick=1]]')).toBe('<tw-link role="link" onclick="window.story.state.onclick=1" data-passage="dest">rename</tw-link>');
     });
 
     it('Should produce right arrow link', () => {
-      expect(Markdown.parse('[[rename->dest]]')).toBe('<tw-link role="link" data-passage="dest">rename</tw-link>');
+      expect(Markdown.parse('[[rename->dest]]')).toBe('<tw-link role="link" onclick="" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce right arrow link with custom onclick', () => {
+      expect(Markdown.parse('[[rename->dest][onclick]]')).toBe('<tw-link role="link" onclick="onclick" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce right link both simple and with custom onclick', () => {
+      expect(Markdown.parse('... [[rename->dest]] ... [[rename->dest][onclick]]')).toBe('... <tw-link role="link" onclick="" data-passage="dest">rename</tw-link> ... <tw-link role="link" onclick="onclick" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce right arrow link with custom onclick with state reference', () => {
+      expect(Markdown.parse('[[rename->dest][s.onclick=1]]')).toBe('<tw-link role="link" onclick="window.story.state.onclick=1" data-passage="dest">rename</tw-link>');
     });
 
     it('Should produce left arrow link', () => {
-      expect(Markdown.parse('[[dest<-rename]]')).toBe('<tw-link role="link" data-passage="dest">rename</tw-link>');
+      expect(Markdown.parse('[[dest<-rename]]')).toBe('<tw-link role="link" onclick="" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce left arrow link with custom onclick', () => {
+      expect(Markdown.parse('[[dest<-rename][onclick]]')).toBe('<tw-link role="link" onclick="onclick" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce left link both simple and with custom onclick', () => {
+      expect(Markdown.parse('... [[dest<-rename]] ... [[dest<-rename][onclick]]')).toBe('... <tw-link role="link" onclick="" data-passage="dest">rename</tw-link> ... <tw-link role="link" onclick="onclick" data-passage="dest">rename</tw-link>');
+    });
+
+    it('Should produce left arrow link with custom onclick with state reference', () => {
+      expect(Markdown.parse('[[dest<-rename][s.onclick=1]]')).toBe('<tw-link role="link" onclick="window.story.state.onclick=1" data-passage="dest">rename</tw-link>');
     });
   });
 


### PR DESCRIPTION
Twine standard links in bar or arrow form (ie. `[[text|passageName]]`) now accept a simple additional expression executed on user click before next passage rendering (ie. `[[text|passageName][onClickCallback]]`).

Very useful to set a variable value (ie. `[[text|passageName][s.myVar=1]]`) or run a custom function (ie. `[[text|passageName][s.myFunc()]]`) that depends on user choice.

Inspired by [SugarCube v2 link feature](http://www.motoslave.net/sugarcube/2/docs/#markup-link).