### PR TITLE
Fixing HTML shorthands for custom elements

### DIFF
--- a/lib/Passage.js
+++ b/lib/Passage.js
@@ -3,50 +3,50 @@ class Passage {
   constructor(id, name, tags, source) {
 
     // Test for jQuery
-    if( !(typeof $ !== 'undefined' && $ !== null) ) {
+    if (!(typeof $ !== 'undefined' && $ !== null)) {
       throw new Error("Global '$' not defined!");
     }
 
     // Test for underscore
-    if( !(typeof _ !== 'undefined' && _ !== null) ) {
+    if (!(typeof _ !== 'undefined' && _ !== null)) {
       throw new Error("Global '_' not defined!");
     }
 
     // Test for marked
-    if( !(typeof marked !== 'undefined' && marked !== null) ) {
+    if (!(typeof marked !== 'undefined' && marked !== null)) {
       throw new Error("Global 'marked' not defined!");
     }
 
     /**
-  	 The numeric ID of the passage.
-  	 @property name
-  	 @type Number
-  	 @readonly
-  	**/
+     The numeric ID of the passage.
+     @property name
+     @type Number
+     @readonly
+    **/
 
     this.id = id || 1;
 
     /**
-  	 The name of the passage.
-  	 @property name
-  	 @type String
-  	**/
+     The name of the passage.
+     @property name
+     @type String
+    **/
 
     this.name = name || "Default";
 
     /**
-  	 The tags of the passage.
-  	 @property tags
-  	 @type Array
-  	**/
+     The tags of the passage.
+     @property tags
+     @type Array
+    **/
 
     this.tags = tags || [];
 
     /**
-  	 The passage source code.
-  	 @property source
-  	 @type String
-  	**/
+     The passage source code.
+     @property source
+     @type String
+    **/
 
     this.source = _.unescape(source);
 
@@ -55,7 +55,7 @@ class Passage {
   render(source) {
 
     // Test if 'source' is defined or not
-    if( !(typeof source !== 'undefined' && source !== null) ) {
+    if (!(typeof source !== 'undefined' && source !== null)) {
       // Assume that 'this.source' is the correct source
       source = this.source
     }
@@ -66,7 +66,7 @@ class Passage {
 
       result = _.template(source)({ s: window.story.state, $: $ });
 
-    } catch(error) {
+    } catch (error) {
 
       $.event.trigger('sm.story.error', [error, "Passage.render() using _.template()"]);
 
@@ -83,78 +83,81 @@ class Passage {
       @return {String} HTML source code
     **/
 
-     function renderAttrs(attrs) {
-       var result = '';
+    function renderAttrs(attrs) {
+      var result = '';
 
-       for (var i = 0; attrs[i] === '-' || attrs[i] === '0'; i++) {
-         switch (attrs[i]) {
-           case '-':
-             result += 'style="display:none" ';
-             break;
+      for (var i = 0; attrs[i] === '-' || attrs[i] === '0'; i++) {
+        switch (attrs[i]) {
+          case '-':
+            result += 'style="display:none" ';
+            break;
 
-           case '0':
-             result += 'href="javascript:void(0)" ';
-             break;
-         }
-       }
+          case '0':
+            result += 'href="javascript:void(0)" ';
+            break;
+        }
+      }
 
-       var classes = [];
-       var id = null;
-       /* eslint-disable no-useless-escape */
-       var classOrId = /([#\.])([^#\.]+)/g;
-       /* eslint-enable no-useless-escape */
-       var matches = classOrId.exec(attrs);
+      var classes = [];
+      var id = null;
+      /* eslint-disable no-useless-escape */
+      var classOrId = /([#\.])([^#\.]+)/g;
+      /* eslint-enable no-useless-escape */
+      var matches = classOrId.exec(attrs);
 
-       while (matches !== null) {
-         switch (matches[1]) {
-           case '#':
-             id = matches[2];
-             break;
+      while (matches !== null) {
+        switch (matches[1]) {
+          case '#':
+            id = matches[2];
+            break;
 
-           case '.':
-             classes.push(matches[2]);
-             break;
-         }
+          case '.':
+            classes.push(matches[2]);
+            break;
+        }
 
-         matches = classOrId.exec(attrs);
-       }
+        matches = classOrId.exec(attrs);
+      }
 
-       if (id !== null) {
+      if (id !== null) {
 
-         result += 'id="' + id + '" ';
+        result += 'id="' + id + '" ';
 
-       }
+      }
 
-       if (classes.length > 0) {
+      if (classes.length > 0) {
 
-         result += 'class="' + classes.join(' ') + '"';
+        result += 'class="' + classes.join(' ') + '"';
 
-       }
+      }
 
-       return result.trim();
+      return result.trim();
 
-     }
+    }
 
 
-     /*
-    	Transform class, ID, hidden, and link shorthands in HTML tags.
+    /*
+     Transform class, ID, hidden, and link shorthands in HTML tags.
 
-    	<a-0.class#id> becomes
-    	<a href="javascript:void(0)" style="display: none" class="class" id="id">
-  	*/
+     <a-0.class#id> becomes
+     <a href="javascript:void(0)" style="display: none" class="class" id="id">
+   */
 
     /* eslint-disable no-useless-escape */
     result = result.replace(
-      /<([a-z]+)([\.#\-0].*?)(?=[\s>])/gi,
-      function(match, tagName, attrs) {
-        return '<' + tagName + ' ' + renderAttrs(attrs);
+      /(?<=<)([\w\-#\.]+)(?=[\s>])/gi,
+      function (match) {
+
+        /* separate tag name from attached shorthands , allowing for custom HTML tags */
+        const [m, tagName, attrs] = match.match(/([a-z]+(?:-[a-z]+)*)(.*)/i);
+        return tagName + ' ' + renderAttrs(attrs);
       }
     );
     /* eslint-enable no-useless-escape */
 
     /* [[links]] with extra markup {#id.class} */
 
-    result = result.replace(/\[\[(.*?)\]\]\{(.*?)\}/g, function(match, target, attrs) {
+    result = result.replace(/\[\[(.*?)\]\]\{(.*?)\}/g, function (match, target, attrs) {
 
       var display = target;
 
@@ -194,13 +197,13 @@ class Passage {
       }
 
       return '<a href="javascript:void(0)" data-passage="' +
-        target + '" ' + renderAttrs(attrs) +  '>' + display + '</a>';
+        target + '" ' + renderAttrs(attrs) + '>' + display + '</a>';
 
     });
 
-     /* Classic [[links]]  */
+    /* Classic [[links]]  */
 
-    result = result.replace(/\[\[(.*?)\]\]/g, function(match, target) {
+    result = result.replace(/\[\[(.*?)\]\]/g, function (match, target) {
 
       var display = target;
 
@@ -236,7 +239,7 @@ class Passage {
       }
 
       return '<a href="javascript:void(0)" data-passage="' +
-      target + '">' + display + '</a>';
+        target + '">' + display + '</a>';
 
     });
 
@@ -247,11 +250,11 @@ class Passage {
       return code;
     };
 
-    marked.setOptions({ smartypants: true, renderer: renderer});
+    marked.setOptions({ smartypants: true, renderer: renderer });
     let newResult = marked(result);
 
     // Test for new <p> tags from Marked
-    if(!result.endsWith('</p>\n') && newResult.endsWith('</p>\n')) {
+    if (!result.endsWith('</p>\n') && newResult.endsWith('</p>\n')) {
 
       newResult = newResult.replace(/^<p>|<\/p>$|<\/p>\n$/g, '');
 

--- a/lib/Passage.js
+++ b/lib/Passage.js
@@ -3,50 +3,50 @@ class Passage {
   constructor(id, name, tags, source) {
 
     // Test for jQuery
-    if (!(typeof $ !== 'undefined' && $ !== null)) {
+    if( !(typeof $ !== 'undefined' && $ !== null) ) {
       throw new Error("Global '$' not defined!");
     }
 
     // Test for underscore
-    if (!(typeof _ !== 'undefined' && _ !== null)) {
+    if( !(typeof _ !== 'undefined' && _ !== null) ) {
       throw new Error("Global '_' not defined!");
     }
 
     // Test for marked
-    if (!(typeof marked !== 'undefined' && marked !== null)) {
+    if( !(typeof marked !== 'undefined' && marked !== null) ) {
       throw new Error("Global 'marked' not defined!");
     }
 
     /**
-     The numeric ID of the passage.
-     @property name
-     @type Number
-     @readonly
-    **/
+  	 The numeric ID of the passage.
+  	 @property name
+  	 @type Number
+  	 @readonly
+  	**/
 
     this.id = id || 1;
 
     /**
-     The name of the passage.
-     @property name
-     @type String
-    **/
+  	 The name of the passage.
+  	 @property name
+  	 @type String
+  	**/
 
     this.name = name || "Default";
 
     /**
-     The tags of the passage.
-     @property tags
-     @type Array
-    **/
+  	 The tags of the passage.
+  	 @property tags
+  	 @type Array
+  	**/
 
     this.tags = tags || [];
 
     /**
-     The passage source code.
-     @property source
-     @type String
-    **/
+  	 The passage source code.
+  	 @property source
+  	 @type String
+  	**/
 
     this.source = _.unescape(source);
 
@@ -55,7 +55,7 @@ class Passage {
   render(source) {
 
     // Test if 'source' is defined or not
-    if (!(typeof source !== 'undefined' && source !== null)) {
+    if( !(typeof source !== 'undefined' && source !== null) ) {
       // Assume that 'this.source' is the correct source
       source = this.source
     }
@@ -66,7 +66,7 @@ class Passage {
 
       result = _.template(source)({ s: window.story.state, $: $ });
 
-    } catch (error) {
+    } catch(error) {
 
       $.event.trigger('sm.story.error', [error, "Passage.render() using _.template()"]);
 
@@ -83,81 +83,82 @@ class Passage {
       @return {String} HTML source code
     **/
 
-    function renderAttrs(attrs) {
-      var result = '';
+     function renderAttrs(attrs) {
+       var result = '';
 
-      for (var i = 0; attrs[i] === '-' || attrs[i] === '0'; i++) {
-        switch (attrs[i]) {
-          case '-':
-            result += 'style="display:none" ';
-            break;
+       for (var i = 0; attrs[i] === '-' || attrs[i] === '0'; i++) {
+         switch (attrs[i]) {
+           case '-':
+             result += 'style="display:none" ';
+             break;
 
-          case '0':
-            result += 'href="javascript:void(0)" ';
-            break;
-        }
-      }
+           case '0':
+             result += 'href="javascript:void(0)" ';
+             break;
+         }
+       }
 
-      var classes = [];
-      var id = null;
-      /* eslint-disable no-useless-escape */
-      var classOrId = /([#\.])([^#\.]+)/g;
-      /* eslint-enable no-useless-escape */
-      var matches = classOrId.exec(attrs);
+       var classes = [];
+       var id = null;
+       /* eslint-disable no-useless-escape */
+       var classOrId = /([#\.])([^#\.]+)/g;
+       /* eslint-enable no-useless-escape */
+       var matches = classOrId.exec(attrs);
 
-      while (matches !== null) {
-        switch (matches[1]) {
-          case '#':
-            id = matches[2];
-            break;
+       while (matches !== null) {
+         switch (matches[1]) {
+           case '#':
+             id = matches[2];
+             break;
 
-          case '.':
-            classes.push(matches[2]);
-            break;
-        }
+           case '.':
+             classes.push(matches[2]);
+             break;
+         }
 
-        matches = classOrId.exec(attrs);
-      }
+         matches = classOrId.exec(attrs);
+       }
 
-      if (id !== null) {
+       if (id !== null) {
 
-        result += 'id="' + id + '" ';
+         result += 'id="' + id + '" ';
 
-      }
+       }
 
-      if (classes.length > 0) {
+       if (classes.length > 0) {
 
-        result += 'class="' + classes.join(' ') + '"';
+         result += 'class="' + classes.join(' ') + '"';
 
-      }
+       }
 
-      return result.trim();
+       return result.trim();
 
-    }
+     }
 
 
-    /*
-     Transform class, ID, hidden, and link shorthands in HTML tags.
+     /*
+    	Transform class, ID, hidden, and link shorthands in HTML tags.
 
-     <a-0.class#id> becomes
-     <a href="javascript:void(0)" style="display: none" class="class" id="id">
-   */
+    	<a-0.class#id> becomes
+    	<a href="javascript:void(0)" style="display: none" class="class" id="id">
+  	*/
 
     /* eslint-disable no-useless-escape */
     result = result.replace(
       /(?<=<)([\w\-#\.]+)(?=[\s>])/gi,
-      function (match) {
+      function(match) {
 
         /* separate tag name from attached shorthands , allowing for custom HTML tags */
         const [m, tagName, attrs] = match.match(/([a-z]+(?:-[a-z]+)*)(.*)/i);
         return tagName + ' ' + renderAttrs(attrs);
       }
     );
+
     /* eslint-enable no-useless-escape */
 
     /* [[links]] with extra markup {#id.class} */
 
-    result = result.replace(/\[\[(.*?)\]\]\{(.*?)\}/g, function (match, target, attrs) {
+    result = result.replace(/\[\[(.*?)\]\]\{(.*?)\}/g, function(match, target, attrs) {
 
       var display = target;
 
@@ -197,13 +198,13 @@ class Passage {
       }
 
       return '<a href="javascript:void(0)" data-passage="' +
-        target + '" ' + renderAttrs(attrs) + '>' + display + '</a>';
+        target + '" ' + renderAttrs(attrs) +  '>' + display + '</a>';
 
     });
 
-    /* Classic [[links]]  */
+     /* Classic [[links]]  */
 
-    result = result.replace(/\[\[(.*?)\]\]/g, function (match, target) {
+    result = result.replace(/\[\[(.*?)\]\]/g, function(match, target) {
 
       var display = target;
 
@@ -239,7 +240,7 @@ class Passage {
       }
 
       return '<a href="javascript:void(0)" data-passage="' +
-        target + '">' + display + '</a>';
+      target + '">' + display + '</a>';
 
     });
 
@@ -250,11 +251,11 @@ class Passage {
       return code;
     };
 
-    marked.setOptions({ smartypants: true, renderer: renderer });
+    marked.setOptions({ smartypants: true, renderer: renderer});
     let newResult = marked(result);
 
     // Test for new <p> tags from Marked
-    if (!result.endsWith('</p>\n') && newResult.endsWith('</p>\n')) {
+    if(!result.endsWith('</p>\n') && newResult.endsWith('</p>\n')) {
 
       newResult = newResult.replace(/^<p>|<\/p>$|<\/p>\n$/g, '');
 

--- a/lib/Passage.js
+++ b/lib/Passage.js
@@ -148,9 +148,15 @@ class Passage {
       /(?<=<)([\w\-#\.]+)(?=[\s>])/gi,
       function(match) {
 
-        /* separate tag name from attached shorthands , allowing for custom HTML tags */
+        // separate tag name from attached shorthands , allowing for custom HTML tags
         const [m, tagName, attrs] = match.match(/([a-z]+(?:-[a-z]+)*)(.*)/i);
-        return tagName + ' ' + renderAttrs(attrs);
+
+        if (attrs.length) {
+          return tagName + ' ' + renderAttrs(attrs);
+        } else {
+          // no attributes to process
+          return tagName
+        }
       }
     );
 


### PR DESCRIPTION
Addressing #834, this adds an extra step to the element processing:
1. grab tag name and any attached shorthand :  `<[custom-tag#id] ...>`
2. separate the two, with a provision for custom tags syntax :  `[custom-tag][#id]`
3. call the shorthand renderer on that second part, if there is one

Compiled and tested on my end, behaved as expected.

Notes:
- Unlike the previous version, this checks every element, not just those that include shorthands.
- The tag's opening bracket isn't part of the match, can easily be reverted.