### PR TITLE
Add mention of `npm run compile` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ Run `npm install` to install dependencies.
 
 `npm run build` will create a Twine 2-ready story format under `dist/`.
 
+`npm run compile` will create the `dist/format.js` file which you can import as a format in to the Twine App.
+
 To check for style errors, run `npm run lint`.
 To run unit tests, run `npm run test`.


### PR DESCRIPTION
Hopefully saves the next newbie from spending a long time trying to figure out why the Twine app can't import `dist/main.js`

PS Would be good to have something on the repo landing page indicating the existence of the separate 2.X branch